### PR TITLE
Update h264-tools to 2025 standards

### DIFF
--- a/ldecod/CMakeLists.txt
+++ b/ldecod/CMakeLists.txt
@@ -1,12 +1,34 @@
-file(GLOB LDECODSRCS "*.c")
+cmake_minimum_required(VERSION 3.10)
+project(H264Decoder C)
 
+# Get all C source files except decoder_test.c (which has its own main function)
+file(GLOB LDECOD_LIB_SRCS "*.c")
+list(REMOVE_ITEM LDECOD_LIB_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/decoder_test.c")
+
+# Set compiler flags
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99 -pedantic -fno-strict-aliasing -fsigned-char -Wall")
-set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O3 -march=native -mtune=native -fopenmp")
-set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} -fopenmp")
+set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O3 -march=native -mtune=native")
+set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE}")
 
-add_executable(ldecod ${LDECODSRCS})
-target_link_libraries(ldecod m)
+# Check for OpenMP support (optional, since some systems might not have it)
+find_package(OpenMP)
+if(OpenMP_C_FOUND)
+    set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -fopenmp")
+    set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} -fopenmp")
+endif()
 
+# Create the decoder library
+add_library(h264decoder_lib STATIC ${LDECOD_LIB_SRCS})
+target_link_libraries(h264decoder_lib m)
+if(OpenMP_C_FOUND)
+    target_link_libraries(h264decoder_lib OpenMP::OpenMP_C)
+endif()
+
+# Create the main decoder executable (ldecod)
+add_executable(ldecod decoder_test.c)
+target_link_libraries(ldecod h264decoder_lib)
+
+# Install targets
 install(TARGETS ldecod DESTINATION bin)
 install(FILES decoder.cfg DESTINATION share)
 

--- a/ldecod/configfile.h
+++ b/ldecod/configfile.h
@@ -18,9 +18,11 @@
 //#define LEVEL_IDC       21
 
 
-InputParameters cfgparams;
+extern InputParameters cfgparams;
 
 #ifdef INCLUDED_BY_CONFIGFILE_C
+InputParameters cfgparams;
+
 // Mapping_Map Syntax:
 // {NAMEinConfigFile,  &cfgparams.VariableName, Type, InitialValue, LimitType, MinLimit, MaxLimit, CharSize}
 // Types : {0:int, 1:text, 2: double}

--- a/ldecod/defines.h
+++ b/ldecod/defines.h
@@ -228,7 +228,7 @@ typedef enum {
 } I8x8PredModes;
 
 // Color components
-enum {
+typedef enum {
   Y_COMP = 0,    // Y Component
   U_COMP = 1,    // U Component
   V_COMP = 2,    // V Component

--- a/scripts/mkv2mkv.in
+++ b/scripts/mkv2mkv.in
@@ -40,12 +40,12 @@ NALUPARSER=$INSTALL_DIR/bin/naluparser
 
 # Temp dir
 TEMPDIR=`mktemp -d`
-OFMT=`echo $OUTPUT|cut -d'.' -f2`
+OFMT=`echo "$OUTPUT"|cut -d'.' -f2`
 
 # input info
 INFO="$TEMPDIR/ffprobe.txt"
 H264STATS="$TEMPDIR/h264stats.txt"
-ffprobe $INPUT 2>&1 |grep "^ *Stream #" > $INFO
+ffprobe "$INPUT" 2>&1 |grep "^ *Stream #" > $INFO
 SL=`cat $INFO|cut -d':' -f2|cut -d'(' -f1|tr "\n" " "`
 FRAMERATE=`cat $INFO|grep "Video:"|head -n 1|cut -d',' -f4|tr -d " fps"`
 RES=`cat $INFO|grep "Video:"|head -n 1|sed "s/([^(]*)//g"|cut -d',' -f3|cut -d' ' -f2`
@@ -58,7 +58,7 @@ MVCDEC="n"
 if [ "$VCODEC" = "h264" ]
 then
 	echo -n "Analysing H.264 video stream ... "
-	CSERATIO=`ffmpeg -v 0 -y -i $INPUT -f h264 -c:v copy pipe:1 </dev/null | $NALUPARSER -nalucount 1000 -stat -b 2>&1 |grep "^20:"|cut -d':' -f2`
+	CSERATIO=`ffmpeg -v 0 -y -i "$INPUT" -f h264 -c:v copy pipe:1 </dev/null | "$NALUPARSER" -nalucount 1000 -stat -b 2>&1 |grep "^20:"|cut -d':' -f2`
 	if [ $CSERATIO -gt 5 ]
 	then
 		echo "3D (MVC) video detected"
@@ -200,7 +200,7 @@ fi
 
 if [ "$MVCDEC" != "y" ]
 then
-	FFMPEG_CMD="ffmpeg -y -strict experimental -i $INPUT $DI_OPT $RES_OPT $MAP_OPT -c:v $VC $BSF_OPT $TUNE_OPT $PRESET_OPT $PROF_OPT $LVL_OPT $VQ_OPT $VR_OPT $COMPAT_OPT $ACHAN_OPT -c:a $AC $AR_OPT $SUB_OPT $OUTPUT"
+	FFMPEG_CMD="ffmpeg -y -strict experimental -i \"$INPUT\" $DI_OPT $RES_OPT $MAP_OPT -c:v $VC $BSF_OPT $TUNE_OPT $PRESET_OPT $PROF_OPT $LVL_OPT $VQ_OPT $VR_OPT $COMPAT_OPT $ACHAN_OPT -c:a $AC $AR_OPT $SUB_OPT \"$OUTPUT\""
 else
 	# named pipes
 	DEMUX_H264="$TEMPDIR/video.h264"
@@ -209,7 +209,7 @@ else
 	YUV_LEFT="$TEMPDIR/dec_ViewId0000.yuv"
 	YUV_RIGHT="$TEMPDIR/dec_ViewId0001.yuv"
 	YUV_SBS="$TEMPDIR/sbs.yuv"
-	$EXECCMD mkfifo $DEMUX_H264 $YUV_LEFT $YUV_RIGHT $YUV_SBS $DEMUX_AUDIOSUB
+	$EXECCMD mkfifo "$DEMUX_H264" "$YUV_LEFT" "$YUV_RIGHT" "$YUV_SBS" "$DEMUX_AUDIOSUB"
 
 	# filter input information
 	let DRES_X=2*$RES_X
@@ -239,30 +239,30 @@ else
 
 	set -x
 	# extract raw H.264+MVC track with AnnexB flavour
-	$EXECCMD ffmpeg -v 0 -y -i $INPUT -map 0:v -f h264 -c:v copy -bsf:v h264_mp4toannexb $DEMUX_H264 &
+	$EXECCMD ffmpeg -v 0 -y -i "$INPUT" -map 0:v -f h264 -c:v copy -bsf:v h264_mp4toannexb $DEMUX_H264 &
 	# extract audio and subtitles
-	$EXECCMD ffmpeg -v 0 -y -i $INPUT -map 0:a $MAPSUB0 -c:a copy $CODECSUB $DEMUX_AUDIOSUB &
+	$EXECCMD ffmpeg -v 0 -y -i "$INPUT" -map 0:a $MAPSUB0 -c:a copy $CODECSUB $DEMUX_AUDIOSUB &
 	$EXECCMD sleep 2
 
 	# decode H.264+MVC stream using Franhauffer JM 18.6 soft
 	#LDECODDBG="-p DecFrmNum=360"
-	$EXECCMD $LDECOD -d $LDECOD_CFG -p DecodeAllLayers=1 -p InputFile=$DEMUX_H264 -p OutputFile=$LDECOD_OUTPUT -p Silent=1 $LDECODDBG >/dev/null&
+	$EXECCMD "$LDECOD" -d "$LDECOD_CFG" -p DecodeAllLayers=1 -p InputFile="$DEMUX_H264" -p OutputFile="$LDECOD_OUTPUT" -p Silent=1 $LDECODDBG >/dev/null&
 	$EXECCMD sleep 2
 
 	# bufferize 2 inputs and output a single Side By Side raw YUV420p stream
-	$EXECCMD $YUVSBSPIPE -w $RES_X -h $RES_Y -n 48 -l $YUV_LEFT -r $YUV_RIGHT $VST_OPT -o $YUV_SBS &
+	$EXECCMD "$YUVSBSPIPE" -w $RES_X -h $RES_Y -n 48 -l "$YUV_LEFT" -r "$YUV_RIGHT" $VST_OPT -o "$YUV_SBS" &
 
 	$EXECCMD sleep 2
-	FFMPEG_CMD="ffmpeg -y -f rawvideo -pixel_format yuv420p -video_size ${ORES_X}x${ORES_Y} -framerate $FRAMERATE -i $YUV_SBS -i $DEMUX_AUDIOSUB -filter_complex [0:v]scale=$RES_X:$RES_Y,setpts=PTS-STARTPTS[video];[1:a]asetpts=PTS-STARTPTS[audio] -map [video] -map [audio] $MAPSUB1 -c:v $VC $TUNE_OPT $PRESET_OPT $PROF_OPT $LVL_OPT $VQ_OPT $VR_OPT $COMPAT_OPT $ACHAN_OPT -c:a $AC $AR_OPT $CODECSUB $OUTPUT"
+	FFMPEG_CMD="ffmpeg -y -f rawvideo -pixel_format yuv420p -video_size ${ORES_X}x${ORES_Y} -framerate $FRAMERATE -i $YUV_SBS -i $DEMUX_AUDIOSUB -filter_complex [0:v]scale=$RES_X:$RES_Y,setpts=PTS-STARTPTS[video];[1:a]asetpts=PTS-STARTPTS[audio] -map [video] -map [audio] $MAPSUB1 -c:v $VC $TUNE_OPT $PRESET_OPT $PROF_OPT $LVL_OPT $VQ_OPT $VR_OPT $COMPAT_OPT $ACHAN_OPT -c:a $AC $AR_OPT $CODECSUB \"$OUTPUT\""
 fi
 
 echo "$FFMPEG_CMD"
-date > $OUTPUT.log
-echo "$FFMPEG_CMD" >> $OUTPUT.log
-$EXECCMD $FFMPEG_CMD 2>&1 | tee -a $OUTPUT.log
-date >> $OUTPUT.log
-cat $OUTPUT.log | grep -v "^frame=" > $OUTPUT.log2
-mv -f $OUTPUT.log2 $OUTPUT.log
+date > "$OUTPUT.log"
+echo "$FFMPEG_CMD" >> "$OUTPUT.log"
+$EXECCMD $FFMPEG_CMD 2>&1 | tee -a "$OUTPUT.log"
+date >> "$OUTPUT.log"
+cat "$OUTPUT.log" | grep -v "^frame=" > "$OUTPUT.log2"
+mv -f "$OUTPUT.log2" "$OUTPUT.log"
 
-rm -fr $TEMPDIR
+rm -fr "$TEMPDIR"
 

--- a/scripts/mkv2mkv.in
+++ b/scripts/mkv2mkv.in
@@ -1,9 +1,28 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # grab command line parameters
 INPUT=$1
 OUTPUT=$2
 EXECCMD=$3
+
+# Validate required parameters
+if [ -z "$INPUT" ] || [ -z "$OUTPUT" ]; then
+    echo "Usage: $0 <input_file> <output_file> [exec_command]"
+    echo ""
+    echo "  input_file    : Input video file to process"
+    echo "  output_file   : Output video file"
+    echo "  exec_command  : Optional command prefix (e.g., for debugging)"
+    echo ""
+    echo "Example: $0 input.mkv output.mkv"
+    exit 1
+fi
+
+# Check if input file exists
+if [ ! -f "$INPUT" ]; then
+    echo "Error: Input file '$INPUT' does not exist"
+    exit 1
+fi
+
 echo "$EXECCMD"
 
 # some constants
@@ -53,6 +72,15 @@ fi
 # filter input information
 RES_X=`echo $RES|cut -d'x' -f1`
 RES_Y=`echo $RES|cut -d'x' -f2`
+
+# Validate resolution values before arithmetic operations
+if [ -z "$RES_X" ] || [ -z "$RES_Y" ] || ! [[ "$RES_X" =~ ^[0-9]+$ ]] || ! [[ "$RES_Y" =~ ^[0-9]+$ ]]; then
+    echo "Error: Could not extract valid resolution from input file"
+    echo "Resolution detected: ${RES_X}x${RES_Y}"
+    echo "Please check if the input file contains a valid video stream"
+    exit 1
+fi
+
 let DRES_X=2*$RES_X
 let DRES_Y=2*$RES_Y
 [ "$FRAMERATE" = "23.98" ] && FRAMERATE="24000/1001"

--- a/scripts/mkv2mkv.in
+++ b/scripts/mkv2mkv.in
@@ -38,6 +38,36 @@ LDECOD=$INSTALL_DIR/bin/ldecod
 YUVSBSPIPE=$INSTALL_DIR/bin/yuvsbspipe
 NALUPARSER=$INSTALL_DIR/bin/naluparser
 
+# Check that all required binaries and files exist
+echo "Checking required dependencies..."
+
+# Check system binaries
+for cmd in ffmpeg ffprobe mktemp; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        echo "Error: Required system binary '$cmd' not found in PATH"
+        echo "Please install $cmd and try again"
+        exit 1
+    fi
+done
+
+# Check custom binaries
+for binary in "$LDECOD" "$YUVSBSPIPE" "$NALUPARSER"; do
+    if [ ! -x "$binary" ]; then
+        echo "Error: Required binary '$binary' not found or not executable"
+        echo "Please build and install the h264-tools project first"
+        exit 1
+    fi
+done
+
+# Check configuration file
+if [ ! -f "$LDECOD_CFG" ]; then
+    echo "Error: Configuration file '$LDECOD_CFG' not found"
+    echo "Please build and install the h264-tools project first"
+    exit 1
+fi
+
+echo "All dependencies found."
+
 # Temp dir
 TEMPDIR=`mktemp -d`
 OFMT=`echo "$OUTPUT"|cut -d'.' -f2`

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,3 +1,6 @@
+cmake_minimum_required(VERSION 3.10)
+project(h264-tools)
+
 add_executable(naluparser naluparser.c)
 add_executable(yuvsbspipe yuvsbspipe.c)
 

--- a/tools/naluparser.c
+++ b/tools/naluparser.c
@@ -1,7 +1,8 @@
 #include <stdio.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
+#include <unistd.h>
 
 enum  	NAL_unit_type {
   UNKNOWN = 0, SLICE = 1, SLICE_DPA = 2, SLICE_DPB = 3,

--- a/tools/yuvsbspipe.c
+++ b/tools/yuvsbspipe.c
@@ -3,7 +3,6 @@
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <malloc.h>
 #include <string.h>
 #include <unistd.h>
 #include <errno.h>


### PR DESCRIPTION
This fixes:
- missing OpenMP (still recommended for performance)
- `ColorComponent` global variable definition instead of just defining an enum type (resulting in multiple definition of `ColorComponent';  error)
- `cfgparams` global variable in a header file
- some missing `cmake_minimum_required` and `project` directives.
- use of deprecated `malloc.h`
- adds some safety checks to `mkv2mkv`